### PR TITLE
Fix text box size in chat screen

### DIFF
--- a/guichatapp/pages.py
+++ b/guichatapp/pages.py
@@ -277,7 +277,7 @@ class ChatPage(Frame):
         self.oplate=Label(self, bg = 'green', fg= 'blue', font='helvetica 18',textvariable=oName, relief=SOLID)
         self.oplate.pack(fill=X)
 
-        self.chat=ScrolledText(self,state=DISABLED,height=27,font='arial 12')
+        self.chat=ScrolledText(self,state=DISABLED,height=26,font='arial 12')
         self.chat.pack(fill=X)
 
         self.chat.tag_config('left',justify='left',foreground='blue',background='pink')


### PR DESCRIPTION
The text box that shows the messages is one row too large currently, which pushes the box for typing messages off the bottom of the window. This PR fixes this by making the box for the messages one row smaller so that everything fits in the window.